### PR TITLE
Fix Pa11y issue 373

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -46,12 +46,15 @@ report.results = results => {
 
 // Internal method used to report an individual result
 report.issue = issue => {
+	const code = issue.code;
+	const selector = issue.selector.replace(/\s+/g, ' ');
+	const context = (issue.context ? issue.context.replace(/\s+/g, ' ') : '[no context]');
 	return cleanWhitespace(`
 
 		${typeStarts[issue.type]} ${issue.message}
-		   ${chalk.grey(`├── ${issue.code}`)}
-		   ${chalk.grey(`├── ${issue.selector.replace(/\s+/g, ' ')}`)}
-		   ${chalk.grey(`└── ${issue.context.replace(/\s+/g, ' ')}`)}
+		   ${chalk.grey(`├── ${code}`)}
+		   ${chalk.grey(`├── ${selector}`)}
+		   ${chalk.grey(`└── ${context}`)}
 	`);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-reporter-cli",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/unit/lib/reporter.js
+++ b/test/unit/lib/reporter.js
@@ -63,7 +63,7 @@ describe('lib/reporter', () => {
 						type: 'notice',
 						code: 'mock-code-3',
 						message: 'mock-message-3',
-						context: 'mock-context-3',
+						context: null,
 						selector: 'mock-selector-3'
 					}
 				]
@@ -87,7 +87,7 @@ describe('lib/reporter', () => {
 				 • Notice: mock-message-3
 				   ├── mock-code-3
 				   ├── mock-selector-3
-				   └── mock-context-3
+				   └── [no context]
 
 				1 Errors
 				1 Warnings


### PR DESCRIPTION
Sometimes the element context that Pa11y sends is null, this didn't
cater for that before. Now we correctly check whether the context is set
before we try and replace on it.

See https://github.com/pa11y/pa11y/issues/373 for more information.