### PR TITLE
Add whitelist of files to be published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "main": "./lib/reporter.js",
   "scripts": {
     "test": "make ci"
-  }
+  },
+  "files": [
+    "/lib"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "test": "make ci"
   },
   "files": [
-    "/lib"
+    "lib"
   ]
 }


### PR DESCRIPTION
This reduces the size of the package from 7.9 kB (23.3 kB unpacked) to 5.2 kB (13.8 kB unpacked).