### PR TITLE
Add runner to the report for each issue. Fixes #8

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -46,13 +46,14 @@ report.results = results => {
 
 // Internal method used to report an individual result
 report.issue = issue => {
+	const runner = issue.runner;
 	const code = issue.code;
 	const selector = issue.selector.replace(/\s+/g, ' ');
 	const context = (issue.context ? issue.context.replace(/\s+/g, ' ') : '[no context]');
 	return cleanWhitespace(`
 
 		${typeStarts[issue.type]} ${issue.message}
-		   ${grey(`├── ${code}`)}
+		   ${grey(`├── ${runner}: ${code}`)}
 		   ${grey(`├── ${selector}`)}
 		   ${grey(`└── ${context}`)}
 	`);

--- a/test/unit/lib/reporter.js
+++ b/test/unit/lib/reporter.js
@@ -48,6 +48,7 @@ describe('lib/reporter', () => {
 					{
 						type: 'error',
 						code: 'mock-code-1',
+						runner: 'axe',
 						message: 'mock-message-1',
 						context: 'mock-context-1',
 						selector: 'mock-selector-1'
@@ -55,6 +56,7 @@ describe('lib/reporter', () => {
 					{
 						type: 'warning',
 						code: 'mock-code-2',
+						runner: 'htmlcs',
 						message: 'mock-message-2',
 						context: 'mock-context-2',
 						selector: 'mock-selector-2'
@@ -62,6 +64,7 @@ describe('lib/reporter', () => {
 					{
 						type: 'notice',
 						code: 'mock-code-3',
+						runner: 'htmlcs',
 						message: 'mock-message-3',
 						context: null,
 						selector: 'mock-selector-3'
@@ -75,17 +78,17 @@ describe('lib/reporter', () => {
 				Results for URL: http://mock-url/
 
 				 • Error: mock-message-1
-				   ├── mock-code-1
+				   ├── axe: mock-code-1
 				   ├── mock-selector-1
 				   └── mock-context-1
 
 				 • Warning: mock-message-2
-				   ├── mock-code-2
+				   ├── htmlcs: mock-code-2
 				   ├── mock-selector-2
 				   └── mock-context-2
 
 				 • Notice: mock-message-3
-				   ├── mock-code-3
+				   ├── htmlcs: mock-code-3
 				   ├── mock-selector-3
 				   └── [no context]
 


### PR DESCRIPTION
This was much easier than I thought :) Here is how to test this, with the change checked out locally, truncated for an illustration of a case where it’s valuable to have the runner displayed:

```txt
$ pa11y --reporter . --runner axe --runner htmlcs --standard WCAG2AAA https://pa11y.org/

[…]

 • Error: Heading levels should only increase by one (https://dequeuniversity.com/rules/axe/3.5/heading-order?application=axeAPI)
   ├── axe: heading-order
   ├── #pa11y-1
   └── <h3 id="pa11y-1"><a href="https://github.com/pa1...</h3>

[…]

 • Error: The heading structure is not logically nested. This h3 element should be an h2 to be properly nested.
   ├── htmlcs: WCAG2AAA.Principle1.Guideline1_3.1_3_1_AAA.G141
   ├── #pa11y-1
   └── <h3 id="pa11y-1"><a href="https://github.com/pa1...</h3>
```

Testing this further, I think I would be interested in also adding this to the CSV and HTML reporters. Does that sound useful?